### PR TITLE
Add support for caching error responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,8 +90,8 @@ violations for your environment.
 --    url - The base URL to iprepd (defaults to "http://localhost:8080/")
 --    cache_ttl - The iprepd response cache ttl in seconds (defaults to 30)
 --    timeout - The timeout for making requests to iprepd in milliseconds (defaults to 10)
---    cache_errors - Enables or disables caching errors. Caching errors will make it so
---                   the average additional latency added by this module is in the 0.5ms
+--    cache_errors - Enables (1) or disables (0) caching errors. Caching errors will make it so
+--                   the average latency added by this module is in the 0.5ms
 --                   range (as long as there is a reasonable cache ttl), but can make
 --                   testing harder. (defaults to disabled)
 --

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ init_by_lua_block {
     threshold = tonumber(os.getenv("IPREPD_REPUTATION_THRESHOLD")),
     cache_ttl = os.getenv("IPREPD_CACHE_TTL") or 30,
     timeout = tonumber(os.getenv("IPREPD_TIMEOUT")) or 10,
+    cache_errors = tonumber(os.getenv("IPREPD_CACHE_ERRORS")),
   })
 }
 
@@ -89,6 +90,10 @@ violations for your environment.
 --    url - The base URL to iprepd (defaults to "http://localhost:8080/")
 --    cache_ttl - The iprepd response cache ttl in seconds (defaults to 30)
 --    timeout - The timeout for making requests to iprepd in milliseconds (defaults to 10)
+--    cache_errors - Enables or disables caching errors. Caching errors will make is so
+--                   that the average additional latency added by this module in the 0.5ms
+--                   range (as long as there is a reasonable cache ttl), but can make
+--                   testing harder.
 --
 client = require("resty.iprepd").new({
   url = "http://127.0.0.1:8080",
@@ -96,6 +101,7 @@ client = require("resty.iprepd").new({
   threshold = 50,
   cache_ttl = 30,
   timeout = 10,
+  cache_errors = 1,
 })
 ```
 
@@ -129,4 +135,5 @@ IPREPD_REPUTATION_THRESHOLD=50  # iprepd reputation threshold, block all IP's wi
 #
 IPREPD_TIMEOUT=10  # iprepd client timeout in milliseconds (default 10ms)
 IPREPD_CACHE_TTL=60 # iprepd response cache ttl in seconds (default 30s)
+IPREPD_CACHE_ERRORS=1 # enables caching iprepd non-200 responses (1 enables, 0 disables, default is 1)
 ```

--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ init_by_lua_block {
     url = os.getenv("IPREPD_URL") or "http://127.0.0.1:8080",
     api_key = os.getenv("IPREPD_API_KEY"),
     threshold = tonumber(os.getenv("IPREPD_REPUTATION_THRESHOLD")),
-    cache_ttl = os.getenv("IPREPD_CACHE_TTL") or 30,
-    timeout = tonumber(os.getenv("IPREPD_TIMEOUT")) or 10,
+    cache_ttl = os.getenv("IPREPD_CACHE_TTL"),
+    timeout = tonumber(os.getenv("IPREPD_TIMEOUT")),
     cache_errors = tonumber(os.getenv("IPREPD_CACHE_ERRORS")),
   })
 }
@@ -90,10 +90,10 @@ violations for your environment.
 --    url - The base URL to iprepd (defaults to "http://localhost:8080/")
 --    cache_ttl - The iprepd response cache ttl in seconds (defaults to 30)
 --    timeout - The timeout for making requests to iprepd in milliseconds (defaults to 10)
---    cache_errors - Enables or disables caching errors. Caching errors will make is so
---                   that the average additional latency added by this module in the 0.5ms
+--    cache_errors - Enables or disables caching errors. Caching errors will make it so
+--                   the average additional latency added by this module is in the 0.5ms
 --                   range (as long as there is a reasonable cache ttl), but can make
---                   testing harder.
+--                   testing harder. (defaults to disabled)
 --
 client = require("resty.iprepd").new({
   url = "http://127.0.0.1:8080",
@@ -133,7 +133,7 @@ IPREPD_REPUTATION_THRESHOLD=50  # iprepd reputation threshold, block all IP's wi
 #
 # optional
 #
-IPREPD_TIMEOUT=10  # iprepd client timeout in milliseconds (default 10ms)
-IPREPD_CACHE_TTL=60 # iprepd response cache ttl in seconds (default 30s)
-IPREPD_CACHE_ERRORS=1 # enables caching iprepd non-200 responses (1 enables, 0 disables, default is 1)
+IPREPD_TIMEOUT=10  # iprepd client timeout in milliseconds (default is 10ms)
+IPREPD_CACHE_TTL=60 # iprepd response cache ttl in seconds (default is 30s)
+IPREPD_CACHE_ERRORS=1 # enables caching iprepd non-200 responses (1 enables, 0 disables, default is 0)
 ```

--- a/README.md
+++ b/README.md
@@ -90,10 +90,10 @@ violations for your environment.
 --    url - The base URL to iprepd (defaults to "http://localhost:8080/")
 --    cache_ttl - The iprepd response cache ttl in seconds (defaults to 30)
 --    timeout - The timeout for making requests to iprepd in milliseconds (defaults to 10)
---    cache_errors - Enables (1) or disables (0) caching errors. Caching errors will make it so
---                   the average latency added by this module is in the 0.5ms
---                   range (as long as there is a reasonable cache ttl), but can make
---                   testing harder. (defaults to disabled)
+--    cache_errors - Enables (1) or disables (0) caching errors. Caching errors is a good
+--                   idea in production, as it can reduce the average additional latency
+--                   caused by this module if anything goes wrong with the underlying
+--                   infrastructure. (defaults to disabled)
 --
 client = require("resty.iprepd").new({
   url = "http://127.0.0.1:8080",

--- a/dist.ini
+++ b/dist.ini
@@ -1,7 +1,7 @@
 name = iprepd-nginx
 abstract = iprepd openresty module
 author = AJ Bahnken (ajvb)
-version = 0.1.1
+version = 0.1.2
 is_original = yes
 license = mozilla2
 lib_dir = lib

--- a/dist.ini
+++ b/dist.ini
@@ -1,7 +1,7 @@
 name = iprepd-nginx
 abstract = iprepd openresty module
 author = AJ Bahnken (ajvb)
-version = 0.1.0
+version = 0.1.1
 is_original = yes
 license = mozilla2
 lib_dir = lib

--- a/etc/conf.d/server.conf
+++ b/etc/conf.d/server.conf
@@ -3,7 +3,7 @@ init_by_lua_block {
     url = os.getenv("IPREPD_URL") or "http://127.0.0.1:8080",
     api_key = os.getenv("IPREPD_API_KEY"),
     threshold = tonumber(os.getenv("IPREPD_REPUTATION_THRESHOLD")),
-    cache_ttl = os.getenv("IPREPD_CACHE_TTL") or 30,
+    cache_ttl = os.getenv("IPREPD_CACHE_TTL"),
     timeout = tonumber(os.getenv("IPREPD_TIMEOUT")) or 10,
     cache_errors = tonumber(os.getenv("IPREPD_CACHE_ERRORS")),
   })

--- a/etc/conf.d/server.conf
+++ b/etc/conf.d/server.conf
@@ -5,6 +5,7 @@ init_by_lua_block {
     threshold = tonumber(os.getenv("IPREPD_REPUTATION_THRESHOLD")),
     cache_ttl = os.getenv("IPREPD_CACHE_TTL") or 30,
     timeout = tonumber(os.getenv("IPREPD_TIMEOUT")) or 10,
+    cache_errors = tonumber(os.getenv("IPREPD_CACHE_ERRORS")),
   })
 }
 

--- a/lib/resty/iprepd.lua
+++ b/lib/resty/iprepd.lua
@@ -32,6 +32,7 @@ function _M.new(options)
     cache_ttl = cache_ttl,
     timeout = options.timeout or 10,
     cache = cache,
+    cache_errors = options.cache_errors or 1,
   }
   return setmetatable(self, mt)
 end
@@ -62,6 +63,10 @@ function _M.check(self, ip)
         ngx.log(ngx.ERR, 'Unable to parse `reputation` value from response body')
       end
     else
+      if self.cache_errors == 1 then
+        self.cache:set(ip, 100, self.cache_ttl)
+      end
+
       ngx.log(ngx.ERR, 'iprepd responded with a ' .. resp.status .. ' http status code')
     end
   end

--- a/lib/resty/iprepd.lua
+++ b/lib/resty/iprepd.lua
@@ -32,7 +32,7 @@ function _M.new(options)
     cache_ttl = cache_ttl,
     timeout = options.timeout or 10,
     cache = cache,
-    cache_errors = options.cache_errors or 1,
+    cache_errors = options.cache_errors or 0,
   }
   return setmetatable(self, mt)
 end
@@ -64,6 +64,7 @@ function _M.check(self, ip)
       end
     else
       if self.cache_errors == 1 then
+        ngx.log(ngx.ERR, 'caching non-200 response, setting reputation of ' .. ip .. ' to 100')
         self.cache:set(ip, 100, self.cache_ttl)
       end
 

--- a/lib/resty/iprepd.lua
+++ b/lib/resty/iprepd.lua
@@ -62,13 +62,14 @@ function _M.check(self, ip)
       else
         ngx.log(ngx.ERR, 'Unable to parse `reputation` value from response body')
       end
+    elseif resp.status == 404 then
+      self.cache:set(ip, 100, self.cache_ttl)
     else
+      ngx.log(ngx.ERR, 'iprepd responded with a ' .. resp.status .. ' http status code')
       if self.cache_errors == 1 then
-        ngx.log(ngx.ERR, 'caching non-200 response, setting reputation of ' .. ip .. ' to 100')
+        ngx.log(ngx.ERR, 'cache_errors is enabled, setting reputation of ' .. ip .. ' to 100 within the cache')
         self.cache:set(ip, 100, self.cache_ttl)
       end
-
-      ngx.log(ngx.ERR, 'iprepd responded with a ' .. resp.status .. ' http status code')
     end
   end
 


### PR DESCRIPTION
Caching error responses and letting subsequent requests to pass through for the TTL period greatly increases the average performance.

With my current infra setup, I'm seeing around ~5ms on average when the nginx module needs to make a request to iprepd. When the error response (specifically 404's) is cached, the average latency overhead is around 0.5ms.