### PR TITLE
Metrics collection via statsd

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ run_dev: Dockerfile
 		-v $(shell pwd)/etc/nginx.conf:/usr/local/openresty/nginx/conf/nginx.conf \
 		-v $(shell pwd)/etc/conf.d:/usr/local/openresty/nginx/conf/conf.d \
 		-v $(shell pwd)/lib/resty/iprepd.lua:/usr/local/openresty/site/lualib/resty/iprepd.lua \
+		-v $(shell pwd)/lib/resty/statsd.lua:/usr/local/openresty/site/lualib/resty/statsd.lua \
 		--rm --network="host" -it $(IMAGE_NAME)
 
 .PHONY: build run_dev

--- a/README.md
+++ b/README.md
@@ -24,12 +24,15 @@ Note: Check out `/etc` in this repo for a working example.
 ```
 init_by_lua_block {
   client = require("resty.iprepd").new({
-    url = os.getenv("IPREPD_URL") or "http://127.0.0.1:8080",
+    url = os.getenv("IPREPD_URL"),
     api_key = os.getenv("IPREPD_API_KEY"),
     threshold = tonumber(os.getenv("IPREPD_REPUTATION_THRESHOLD")),
     cache_ttl = os.getenv("IPREPD_CACHE_TTL"),
-    timeout = tonumber(os.getenv("IPREPD_TIMEOUT")),
+    timeout = tonumber(os.getenv("IPREPD_TIMEOUT")) or 10,
     cache_errors = tonumber(os.getenv("IPREPD_CACHE_ERRORS")),
+    statsd_host = os.getenv("STATSD_HOST") or nil,
+    statsd_port = tonumber(os.getenv("STATSD_PORT")) or 8125,
+    statsd_buffer_size = tonumber(os.getenv("STATSD_BUFFER_SIZE")) or 100,
   })
 }
 
@@ -94,6 +97,10 @@ violations for your environment.
 --                   idea in production, as it can reduce the average additional latency
 --                   caused by this module if anything goes wrong with the underlying
 --                   infrastructure. (defaults to disabled)
+--    statsd_host - Host of statsd collector. Setting this will enable statsd metrics collection
+--    statsd_port - Port of statsd collector. (defaults to 8125)
+--    statsd_buffer_size - Statsd buffer table length at which stats should be sent to
+--                         the collector. (defaults to 100)
 --
 client = require("resty.iprepd").new({
   url = "http://127.0.0.1:8080",
@@ -102,6 +109,9 @@ client = require("resty.iprepd").new({
   cache_ttl = 30,
   timeout = 10,
   cache_errors = 1,
+  statsd_host = "127.0.0.1",
+  statsd_port = 8125,
+  statsd_buffer_size = 100,
 })
 ```
 
@@ -136,4 +146,7 @@ IPREPD_REPUTATION_THRESHOLD=50  # iprepd reputation threshold, block all IP's wi
 IPREPD_TIMEOUT=10  # iprepd client timeout in milliseconds (default is 10ms)
 IPREPD_CACHE_TTL=60 # iprepd response cache ttl in seconds (default is 30s)
 IPREPD_CACHE_ERRORS=1 # enables caching iprepd non-200 responses (1 enables, 0 disables, default is 0)
+STATSD_HOST=127.0.0.1 # statsd host, setting this will also enable statsd metrics collection.
+STATSD_PORT=8125 # statsd port (default is 8125)
+STATSD_BUFFER_SIZE=200 # statsd buffer size (default is 100)
 ```

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ init_by_lua_block {
     cache_errors = tonumber(os.getenv("IPREPD_CACHE_ERRORS")),
     statsd_host = os.getenv("STATSD_HOST") or nil,
     statsd_port = tonumber(os.getenv("STATSD_PORT")) or 8125,
-    statsd_buffer_size = tonumber(os.getenv("STATSD_BUFFER_SIZE")) or 100,
+    statsd_max_buffer_count = tonumber(os.getenv("STATSD_MAX_BUFFER_COUNT")) or 100,
   })
 }
 
@@ -99,8 +99,8 @@ violations for your environment.
 --                   infrastructure. (defaults to disabled)
 --    statsd_host - Host of statsd collector. Setting this will enable statsd metrics collection
 --    statsd_port - Port of statsd collector. (defaults to 8125)
---    statsd_buffer_size - Statsd buffer table length at which stats should be sent to
---                         the collector. (defaults to 100)
+--    statsd_max_buffer_count - Max number of metrics in buffer before metrics should be submitted
+--                              to statsd (defaults to 100)
 --
 client = require("resty.iprepd").new({
   url = "http://127.0.0.1:8080",
@@ -111,7 +111,7 @@ client = require("resty.iprepd").new({
   cache_errors = 1,
   statsd_host = "127.0.0.1",
   statsd_port = 8125,
-  statsd_buffer_size = 100,
+  statsd_max_buffer_count = 100,
 })
 ```
 
@@ -148,5 +148,5 @@ IPREPD_CACHE_TTL=60 # iprepd response cache ttl in seconds (default is 30s)
 IPREPD_CACHE_ERRORS=1 # enables caching iprepd non-200 responses (1 enables, 0 disables, default is 0)
 STATSD_HOST=127.0.0.1 # statsd host, setting this will also enable statsd metrics collection.
 STATSD_PORT=8125 # statsd port (default is 8125)
-STATSD_BUFFER_SIZE=200 # statsd buffer size (default is 100)
+STATSD_MAX_BUFFER_COUNT=200 # statsd max number of buffer items before submitting (default is 100)
 ```

--- a/dist.ini
+++ b/dist.ini
@@ -1,7 +1,7 @@
 name = iprepd-nginx
 abstract = iprepd openresty module
 author = AJ Bahnken (ajvb)
-version = 0.1.2
+version = 0.1.3
 is_original = yes
 license = mozilla2
 lib_dir = lib

--- a/etc/conf.d/server.conf
+++ b/etc/conf.d/server.conf
@@ -8,7 +8,7 @@ init_by_lua_block {
     cache_errors = tonumber(os.getenv("IPREPD_CACHE_ERRORS")),
     statsd_host = os.getenv("STATSD_HOST") or nil,
     statsd_port = tonumber(os.getenv("STATSD_PORT")) or 8125,
-    statsd_buffer_size = tonumber(os.getenv("STATSD_BUFFER_SIZE")) or 100,
+    statsd_max_buffer_count = tonumber(os.getenv("STATSD_MAX_BUFFER_COUNT")) or 100,
   })
 }
 

--- a/etc/conf.d/server.conf
+++ b/etc/conf.d/server.conf
@@ -6,6 +6,9 @@ init_by_lua_block {
     cache_ttl = os.getenv("IPREPD_CACHE_TTL"),
     timeout = tonumber(os.getenv("IPREPD_TIMEOUT")) or 10,
     cache_errors = tonumber(os.getenv("IPREPD_CACHE_ERRORS")),
+    statsd_host = os.getenv("STATSD_HOST") or nil,
+    statsd_port = tonumber(os.getenv("STATSD_PORT")) or 8125,
+    statsd_buffer_size = tonumber(os.getenv("STATSD_BUFFER_SIZE")) or 100,
   })
 }
 
@@ -25,15 +28,31 @@ server {
 
   set_by_lua_block $backend { return os.getenv("backend") }
 
-  # Default location, will enforce authentication there
   location / {
     proxy_set_header "X-Forwarded-Port" $server_port;
     proxy_set_header "X-Forwarded-For" $proxy_add_x_forwarded_for;
     proxy_set_header "X-Real-IP" $remote_addr;
     proxy_set_header "Host" $host;
+    proxy_pass $backend;
+
     access_by_lua_block {
       client:check(ngx.var.remote_addr)
+      if client.statsd then
+        ngx.location.capture("/stats")
+      end
     }
-    proxy_pass $backend;
+
+    log_by_lua_block {
+      if client.statsd then
+        client.statsd.set("iprepd.ips_seen", ngx.var.remote_addr)
+      end
+    }
   }
+
+  location /stats {
+    content_by_lua_block {
+      client:flush_stats()
+    }
+  }
+
 }

--- a/lib/resty/iprepd.lua
+++ b/lib/resty/iprepd.lua
@@ -47,7 +47,7 @@ function _M.new(options)
     statsd = statsd_client,
     statsd_host = options.statsd_host,
     statsd_port = options.statsd_port or 8125,
-    statsd_buffer_size =  options.statsd_buffer_size or 100,
+    statsd_max_buffer_count =  options.statsd_max_buffer_count or 100,
   }
   return setmetatable(self, mt)
 end
@@ -108,7 +108,7 @@ end
 
 function _M.flush_stats(self)
   if self.statsd then
-    if #self.statsd.buffer >= self.statsd_buffer_size then
+    if self.statsd.buffer_count() >= self.statsd_max_buffer_count then
       self.statsd.flush(self.statsd_host, self.statsd_port)
     end
   end

--- a/lib/resty/statsd.lua
+++ b/lib/resty/statsd.lua
@@ -1,0 +1,47 @@
+--
+-- Forked from https://github.com/lonelyplanet/openresty-statsd
+--
+local _M = {}
+
+-- this table will be shared per worker process
+-- if lua_code_cache is off, it will be cleared every request
+_M.buffer = {}
+
+function _M.flush(host, port)
+  if pcall(function()
+    local udp = ngx.socket.udp()
+    udp:setpeername(host, port)
+    udp:send(_M.buffer)
+    udp:close()
+  end) then
+    -- pass
+  else
+    ngx.log(ngx.ERR, "Error sending stats to statsd at " .. host .. ":" .. port)
+  end
+
+  for k in pairs(_M.buffer) do
+    _M.buffer[k] = nil
+  end
+end
+
+function _M.register(bucket, suffix)
+  table.insert(_M.buffer, bucket .. ':' .. suffix .. '\n')
+end
+
+function _M.time(bucket, time)
+  _M.register(bucket, time .. '|ms')
+end
+
+function _M.set(bucket, value)
+  _M.register(bucket, value .. '|s')
+end
+
+function _M.count(bucket, n)
+  _M.register(bucket, n .. '|c')
+end
+
+function _M.incr(bucket)
+  _M.count(bucket, 1)
+end
+
+return _M


### PR DESCRIPTION
Adds support for enabling metrics collection via statsd. `client:flush_stats()` added so that sending to statsd can be done in a non-blocking way.

Fixes #3 