### PR TITLE
0.1.7

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 IMAGE_NAME	:= "iprepd-nginx"
 
 build: Dockerfile
-	docker build -t $(IMAGE_NAME) .
+	docker build --no-cache -t $(IMAGE_NAME) .
 
 run_dev: Dockerfile
 	docker run \

--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ client = require("resty.iprepd").new({
 | iprepd.err.timeout | count | Request to iprepd timed out |
 | iprepd.err.500 | count | Got a 500 response from iprepd |
 | iprepd.err.401 | count | Got a 401 response from iprepd, usually means the API key in use is invalid or being sent incorrectly by nginx. |
+| iprepd.err.dns_timeout | count | DNS resolution of the iprepd URL's domain name timed out. Make sure to check nginx's [resolver_timeout](https://nginx.org/en/docs/http/ngx_http_core_module.html#resolver_timeout) setting |
 | iprepd.err.* | count | Got an error while sending a request to iprepd. This could be other 4xx or 5xx status codes for example. |
 
 

--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ client = require("resty.iprepd").new({
 | iprepd.status.below_threshold | count | The reputation for the client ip is below the configured threshold. |
 | iprepd.status.rejected | count | The request was blocked (won’t be sent if `blocking_mode` is disabled). |
 | iprepd.status.accepted | count | The request was accepted. The reputation can still be below the threshold if `blocking_mode` is disabled.
+| iprepd.get_reputation | count | Request to iprepd |
 | iprepd.err.timeout | count | Request to iprepd timed out |
 | iprepd.err.500 | count | Got a 500 response from iprepd |
 | iprepd.err.401 | count | Got a 401 response from iprepd, usually means the API key in use is invalid or being sent incorrectly by nginx. |

--- a/README.md
+++ b/README.md
@@ -92,8 +92,8 @@ violations for your environment.
 --    statsd_max_buffer_count - Max number of metrics in buffer before metrics should be submitted
 --                              to statsd (defaults to 100)
 --    statsd_flush_timer - Interval for attempting to flush the stats in seconds. (defaults to 5)
---    dont_block - Enables (1) or disables (0) not blocking within nginx by returning
---                 a 403. (defaults to disabled)
+--    blocking_mode - Enables (1) or disables (0) blocking within nginx by returning a
+--                    403. (defaults to disabled)
 --    verbose - Enables (1) or disables (0) verbose logging. Messages are logged with a
 --              severity of "ERROR" so that nginx log levels do not need to be changed. (defaults
 --              to disabled)
@@ -111,7 +111,7 @@ client = require("resty.iprepd").new({
   statsd_port = 8125,
   statsd_max_buffer_count = 100,
   statsd_flush_timer = 10,
-  dont_block = 0,
+  blocking_mode = 0,
   verbose = 0,
   whitelist = {"127.0.0.1", "10.10.10.0/24", "192.168.0.0/16"}
 })
@@ -124,8 +124,8 @@ client = require("resty.iprepd").new({
 | name | type | description |
 |---|---|---|
 | iprepd.status.below_threshold | count | The reputation for the client ip is below the configured threshold. |
-| iprepd.status.rejected | count | The request was blocked (won’t be sent if `dont_block` is enabled). |
-| iprepd.status.accepted | count | The reputation for the client ip is above the configured threshold and was accepted. |
+| iprepd.status.rejected | count | The request was blocked (won’t be sent if `blocking_mode` is disabled). |
+| iprepd.status.accepted | count | The request was accepted. The reputation can still be below the threshold if `blocking_mode` is disabled.
 | iprepd.err.timeout | count | Request to iprepd timed out |
 | iprepd.err.500 | count | Got a 500 response from iprepd |
 | iprepd.err.401 | count | Got a 401 response from iprepd, usually means the API key in use is invalid or being sent incorrectly by nginx. |
@@ -226,5 +226,5 @@ STATSD_HOST=127.0.0.1
 STATSD_PORT=8125
 STATSD_MAX_BUFFER_COUNT=200
 STATSD_FLUSH_TIMER=2
-DONT_BLOCK=0
+BLOCKING_MODE=0
 ```

--- a/dist.ini
+++ b/dist.ini
@@ -1,7 +1,7 @@
 name = iprepd-nginx
 abstract = iprepd openresty module
 author = AJ Bahnken (ajvb)
-version = 0.1.6
+version = 0.1.7
 is_original = yes
 license = mozilla2
 lib_dir = lib

--- a/etc/conf.d/server.conf
+++ b/etc/conf.d/server.conf
@@ -10,7 +10,7 @@ init_by_lua_block {
     statsd_port = tonumber(os.getenv("STATSD_PORT")) or 8125,
     statsd_max_buffer_count = tonumber(os.getenv("STATSD_MAX_BUFFER_COUNT")) or 100,
     statsd_flush_timer = tonumber(os.getenv("STATSD_FLUSH_TIMER")) or 5,
-    dont_block = tonumber(os.getenv("DONT_BLOCK")) or 0,
+    blocking_mode = tonumber(os.getenv("BLOCKING_MODE")) or 0,
     verbose = tonumber(os.getenv("VERBOSE")) or 0,
     whitelist = {},
   })

--- a/lib/resty/iprepd.lua
+++ b/lib/resty/iprepd.lua
@@ -95,7 +95,6 @@ function _M.check(self, ip)
         end
         ngx.exit(ngx.HTTP_FORBIDDEN)
       end
-
     end
   end
 
@@ -115,6 +114,7 @@ function _M.get_reputation(self, ip)
       method  = "GET",
       headers = self.api_key_hdr,
     })
+    self.statsd.incr("iprepd.get_reputation")
     if err then
       if self.statsd then
         self.statsd.incr("iprepd.err." .. err)

--- a/lib/resty/iprepd.lua
+++ b/lib/resty/iprepd.lua
@@ -120,6 +120,8 @@ function _M.get_reputation(self, ip)
         if string.find(err, " ") then
           if string.find(err, "could not be resolved") and string.find(err, "Operation timed out") then
             self.statsd.incr("iprepd.err.dns_timeout")
+          else
+            ngx.log(ngx.ERR, string.format("Could not send metric with error: %s", err))
           end
         else
           self.statsd.incr("iprepd.err." .. err)

--- a/lib/resty/iprepd.lua
+++ b/lib/resty/iprepd.lua
@@ -117,7 +117,13 @@ function _M.get_reputation(self, ip)
     self.statsd.incr("iprepd.get_reputation")
     if err then
       if self.statsd then
-        self.statsd.incr("iprepd.err." .. err)
+        if string.find(err, " ") then
+          if string.find(err, "could not be resolved") and string.find(err, "Operation timed out") then
+            self.statsd.incr("iprepd.err.dns_timeout")
+          end
+        else
+          self.statsd.incr("iprepd.err." .. err)
+        end
       end
       ngx.log(ngx.ERR, string.format("Error with request to iprepd: %s", err))
       return nil

--- a/lib/resty/iprepd.lua
+++ b/lib/resty/iprepd.lua
@@ -55,7 +55,7 @@ function _M.new(options)
     statsd_port = options.statsd_port or 8125,
     statsd_max_buffer_count =  options.statsd_max_buffer_count or 100,
     statsd_flush_timer = options.statsd_flush_timer or 5,
-    dont_block = options.dont_block or 0,
+    blocking_mode = options.blocking_mode or 0,
     verbose = options.verbose or 0,
     whitelist = whitelist,
   }
@@ -86,7 +86,7 @@ function _M.check(self, ip)
         self.statsd.incr("iprepd.status.below_threshold")
       end
 
-      if self.dont_block == 1 then
+      if self.blocking_mode == 0 then
         ngx.log(ngx.ERR, string.format("%s is below threshold with a reputation of %d", ip, reputation))
       else
         ngx.log(ngx.ERR, string.format("%s rejected with a reputation of %d", ip, reputation))
@@ -96,7 +96,6 @@ function _M.check(self, ip)
         ngx.exit(ngx.HTTP_FORBIDDEN)
       end
 
-      return
     end
   end
 


### PR DESCRIPTION
* Replace `dont_block` variable with the less confusing `blocking_mode`. Also makes it off by default.
* Remove early return so that `iprepd.status.accepted` is always set when a request is not blocked.
* Gather new metric for total calls to iprepd's get reputation endpoint (`iprepd.get_reputation`)
* Gather new metric for dns timeouts to iprepd's domain name. (`iprepd.err.dns_timeout`)


cc: @milescrabill - Will need to swap the "blocking enabled" variables in cloudops-infra back to what you had them at :)